### PR TITLE
Move request time from message string to log context

### DIFF
--- a/src/RequestFilter.php
+++ b/src/RequestFilter.php
@@ -59,8 +59,11 @@ class RequestFilter implements SilverStripeRequestFilter
                 $time = microtime(true) - $info[1];
                 if ($time > $this->timeLimit) {
                     $this->logger->info(
-                        sprintf("Slow request time %01.2f secs at '%s'", $time, $request->getURL()),
-                        array('request' => (array) $request)
+                        sprintf("Slow request time at '%s'", $request->getURL()),
+                        array(
+                            'time' => sprintf('%01.2fs', $time),
+                            'request' => (array) $request
+                        )
                     );
                 }
                 unset($this->times[$key]);


### PR DESCRIPTION
Having the request time in the message context allows the time value to be parsed more easily than when it is part of the message string. The rendering doesn't differ too much with this change, so it is still readable as text.

With this change, log messages are written as:

```
[2015-02-03 10:24:46] App.INFO: Slow request time at 'home' {"time":"1.21s","request": ...
```

instead of:

```
[2015-02-03 14:32:06] App.INFO: Slow request time 1.21 secs at 'home' {"request": ...
```
